### PR TITLE
Fix: Enable HTML rendering on list page description

### DIFF
--- a/src/Controller/BucketListController.php
+++ b/src/Controller/BucketListController.php
@@ -22,7 +22,7 @@ class BucketListController extends ControllerBase {
     ]);
     $build['bucket_description'] = [
       '#type' => 'markup',
-      '#markup' => '<div class="bucket-desc">' . nl2br(htmlspecialchars($desc)) . '</div>',
+      '#markup' => '<div class="bucket-desc">' . nl2br($desc) . '</div>',
     ];
 
     // Upload button at top.


### PR DESCRIPTION
The previous commit enabled HTML in the description on the upload form, but missed the list page at `/bucket`. This caused HTML tags to be displayed as plain text on the list page.

This commit removes the `htmlspecialchars()` function from the description rendering logic in `BucketListController.php`, ensuring that the description's HTML is rendered correctly on both the upload and list pages.