### PR TITLE
The /bucket page was being cached, which caused anonymous users to se…

### DIFF
--- a/src/Controller/BucketListController.php
+++ b/src/Controller/BucketListController.php
@@ -111,6 +111,21 @@ class BucketListController extends ControllerBase {
       '#empty' => $this->t('No files yet.'),
     ];
 
+    // Add no-index to the page.
+    $build['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'robots',
+          'content' => 'noindex, nofollow',
+        ],
+      ],
+      'bucket_no_index',
+    ];
+
+    // Disable caching on this page.
+    $build['#cache']['max-age'] = 0;
+
     return $build;
   }
 


### PR DESCRIPTION
…e stale data.

This change disables caching for the page by setting the cache max-age to 0. It also adds a "noindex, nofollow" meta tag to prevent the page from being indexed by search engines.